### PR TITLE
Use Buildkit's TARGETARCH to decide which GOSU to download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM openjdk:8-jre
 LABEL maintainer="Rodolphe CHAIGNEAU <rodolphe.chaigneau@gmail.com>"
 
 ENV WIREMOCK_VERSION 2.31.0
-ENV GOSU_VERSION 1.10
+ENV GOSU_VERSION 1.14
 
 ARG TARGETARCH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,12 @@ LABEL maintainer="Rodolphe CHAIGNEAU <rodolphe.chaigneau@gmail.com>"
 ENV WIREMOCK_VERSION 2.31.0
 ENV GOSU_VERSION 1.10
 
+ARG TARGETARCH
+
 # grab gosu for easy step-down from root
 RUN set -x \
-  && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
-  && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+  && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$TARGETARCH" \
+  && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$TARGETARCH.asc" \
   && export GNUPGHOME="$(mktemp -d)" \
   && for server in $(shuf -e ha.pool.sks-keyservers.net \
     hkp://p80.pool.sks-keyservers.net:80 \


### PR DESCRIPTION
This is slightly cleaner than detecting using dpkg, but does require buildkit (or a default for the build argument in cases of non-buildkit builds)

This will also make multi-architecture builds simpler (see #44)