### PR TITLE
Upgrade images to Java 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:jre
+FROM eclipse-temurin:17-jre
 
 LABEL maintainer="Rodolphe CHAIGNEAU <rodolphe.chaigneau@gmail.com>"
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:alpine-jre
+FROM eclipse-temurin:17-jre-alpine
 
 LABEL maintainer="Rodolphe CHAIGNEAU <rodolphe.chaigneau@gmail.com>"
 


### PR DESCRIPTION
Update images to support latest LTS Java version 17.
Wiremock itself only needs Java 8, but to integrate own extension build with a newer JDK version, a newer java version would allow the usage of the image by a larger user-base.