### PR TITLE
Add community Slack badge to the header

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,6 @@
 # Wiremock Docker
 [![Main](https://github.com/wiremock/wiremock-docker/actions/workflows/main.yml/badge.svg)](https://github.com/wiremock/wiremock-docker/actions/workflows/main.yml) [![Nightly](https://github.com/wiremock/wiremock-docker/actions/workflows/nightly.yml/badge.svg)](https://github.com/wiremock/wiremock-docker/actions/workflows/nightly.yml) [![Docker Pulls](https://img.shields.io/docker/pulls/wiremock/wiremock.svg)](https://hub.docker.com/r/wiremock/wiremock/)
+[![a](https://img.shields.io/badge/slack-Join%20us-brightgreen?style=flat&logo=slack)](https://slack.wiremock.org/)
 
 > [Wiremock](http://wiremock.org) standalone HTTP server Docker image
 


### PR DESCRIPTION
Same as for other repositories. It would be useful to have it on DockerHub landing too, IIUC it is auto-propagated at the moment