### PR TITLE
Update Java to Eclipse Temurin JRE 11 latest version AND pin the version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:jre
+FROM eclipse-temurin:11.0.19_7-jre
 
 LABEL maintainer="Rodolphe CHAIGNEAU <rodolphe.chaigneau@gmail.com>"
 

--- a/Dockerfile-nightly
+++ b/Dockerfile-nightly
@@ -12,7 +12,7 @@ RUN ./gradlew shadowJar
 
 # RUN
 
-FROM adoptopenjdk/openjdk11:jre
+FROM eclipse-temurin:11.0.19_7-jre
 
 LABEL maintainer="Rodolphe CHAIGNEAU <rodolphe.chaigneau@gmail.com>"
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:alpine-jre
+FROM eclipse-temurin:11.0.19_7-jre-alpine
 
 LABEL maintainer="Rodolphe CHAIGNEAU <rodolphe.chaigneau@gmail.com>"
 

--- a/alpine/Dockerfile-nightly
+++ b/alpine/Dockerfile-nightly
@@ -10,7 +10,7 @@ RUN ./gradlew shadowJar
 
 # RUN
 
-FROM adoptopenjdk/openjdk11:alpine-jre
+FROM eclipse-temurin:11.0.19_7-jre-alpine
 
 LABEL maintainer="Rodolphe CHAIGNEAU <rodolphe.chaigneau@gmail.com>"
 


### PR DESCRIPTION
For https://github.com/wiremock/wiremock-docker/issues/64 . Later we will need Dependabot or Update CLI to bump the images