### PR TITLE
Create placeholder directories for mappings, files and extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,11 @@ RUN mkdir -p /var/wiremock/lib/ \
   && curl https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-jre8-standalone/$WIREMOCK_VERSION/wiremock-jre8-standalone-$WIREMOCK_VERSION.jar \
     -o /var/wiremock/lib/wiremock-jre8-standalone.jar
 
+# Init WireMock files structure
+RUN mkdir -p /home/wiremock/mappings && \
+	mkdir -p /home/wiremock/__files && \
+	mkdir -p /var/wiremock/extensions
+
 COPY docker-entrypoint.sh /
 
 EXPOSE 8080 8443

--- a/Dockerfile-nightly
+++ b/Dockerfile-nightly
@@ -22,6 +22,11 @@ COPY --from=builder /workdir/build/libs/*.jar /var/wiremock/lib/wiremock-jre8-st
 
 COPY docker-entrypoint.sh /
 
+# Init WireMock files structure
+RUN mkdir -p /home/wiremock/mappings && \
+	mkdir -p /home/wiremock/__files && \
+	mkdir -p /var/wiremock/extensions
+
 EXPOSE 8080 8443
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -17,6 +17,11 @@ RUN mkdir -p /var/wiremock/lib/ \
   && wget https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-jre8-standalone/$WIREMOCK_VERSION/wiremock-jre8-standalone-$WIREMOCK_VERSION.jar \
     -O /var/wiremock/lib/wiremock-jre8-standalone.jar
 
+# Init WireMock files structure
+RUN mkdir -p /home/wiremock/mappings && \
+	mkdir -p /home/wiremock/__files && \
+	mkdir -p /var/wiremock/extensions
+
 COPY docker-entrypoint.sh /
 
 EXPOSE 8080 8443

--- a/alpine/Dockerfile-nightly
+++ b/alpine/Dockerfile-nightly
@@ -24,6 +24,11 @@ RUN apk add --no-cache 'su-exec>=0.2' bash
 
 COPY --from=builder /workdir/build/libs/*.jar /var/wiremock/lib/wiremock-jre8-standalone.jar
 
+# Init WireMock files structure
+RUN mkdir -p /home/wiremock/mappings && \
+	mkdir -p /home/wiremock/__files && \
+	mkdir -p /var/wiremock/extensions
+
 COPY docker-entrypoint.sh /
 
 EXPOSE 8080 8443


### PR DESCRIPTION
Allows using the official image together with Testcontainers implementations that cannot yet create directories for copying files. For https://github.com/wiremock/wiremock-testcontainers-go/issues/2 