### PR TITLE
Update IT to the 1.0-alpha-6 version + Adopt Testcontainers integration tests in Main and Nightly baseline builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,4 +53,4 @@ jobs:
     
       - name: Run integration test
         working-directory: test/integration-tests
-        run: mvn -B -ntp package verify --file pom.xml -DargLine="-Dit.wiremock-image=${{ matrix.versions.TAGS[0] }}
+        run: mvn -B -ntp package verify --file pom.xml -DargLine="-Dit.wiremock-image=${{ matrix.versions.TAGS[0] }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,9 @@ jobs:
           - CONTEXT: .
             TAGS:
               - wiremock/wiremock:test
-            TEST_WIREMOCK_VERSION: test
           - CONTEXT: alpine
             TAGS:
               - wiremock/wiremock:test-alpine
-            TEST_WIREMOCK_VERSION: test-alpine
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -55,4 +53,4 @@ jobs:
     
       - name: Run integration test
         working-directory: test/integration-tests
-        run: mvn -B -ntp package verify --file pom.xml -DargLine="-Dit.wiremock-version=${{ matrix.versions.TEST_WIREMOCK_VERSION }}"
+        run: mvn -B -ntp package verify --file pom.xml -DargLine="-Dit.wiremock-image=${{ matrix.versions.TAGS[0] }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,32 +62,22 @@ jobs:
           load: true
           tags: ${{ matrix.versions.TAGS[0] }}
 
-      - name: Test WireMock Docker image
-        run: |
-          # default
-          docker container run -d --name test -p 8080:8080 ${{ matrix.versions.TAGS[0] }}
-          timeout 10 bash -c 'while ! curl --fail http://localhost:8080/__admin/; do sleep 1; done'
-          docker container rm -f test
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'temurin'
+          cache: maven
+    
+      - name: Run integration test
+        working-directory: test/integration-tests
+        run: mvn -B -ntp package verify --file pom.xml -DargLine="-Dit.wiremock-image=${{ matrix.versions.TAGS[0] }}"
 
-          # args
+      - name: Test WireMock Docker image with SSL
+        run: |
           docker container run -d --name test -p 8443:8443 ${{ matrix.versions.TAGS[0] }} --https-port 8443
           timeout 10 bash -c 'while ! curl --fail --insecure https://localhost:8443/__admin/; do sleep 1; done'
           docker container rm -f test
-
-          if [ "${{ matrix.versions.CONTEXT }}" != "alpine" ]
-          then
-            # helloworld
-            docker buildx build --tag wiremock-hello --load samples/hello
-            docker container run -d --name test -p 8080:8080 wiremock-hello
-            timeout 10 bash -c 'while ! curl --fail http://localhost:8080/hello; do sleep 1; done'
-            docker container rm -f test
-
-            # random
-            docker buildx build --tag wiremock-random --load samples/random
-            docker container run -d --name test -p 8080:8080 wiremock-random
-            timeout 10 bash -c 'while ! curl --fail http://localhost:8080/random; do sleep 1; done'
-            docker container rm -f test
-          fi
 
       - name: Push Wiremock Docker image
         uses: docker/build-push-action@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -66,32 +66,22 @@ jobs:
       - name: Build Wiremock Docker image
         run: docker buildx build --tag ${{ matrix.versions.TAGS[0] }} --load ${{ matrix.versions.CONTEXT }} --file ${{ matrix.versions.CONTEXT }}/Dockerfile-nightly
 
-      - name: Test Wiremock Docker image
-        run: |
-          # default
-          docker container run -d --name test -p 8080:8080 ${{ matrix.versions.TAGS[0] }}
-          timeout 10 bash -c 'while ! curl --fail http://localhost:8080/__admin/; do sleep 1; done'
-          docker container rm -f test
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'temurin'
+          cache: maven
+    
+      - name: Run integration test
+        working-directory: test/integration-tests
+        run: mvn -B -ntp package verify --file pom.xml -DargLine="-Dit.wiremock-image=${{ matrix.versions.TAGS[0] }}"
 
-          # args
+      - name: Test Wiremock Docker image with SSL
+        run: |
           docker container run -d --name test -p 8443:8443 ${{ matrix.versions.TAGS[0] }} --https-port 8443
           timeout 10 bash -c 'while ! curl --fail --insecure https://localhost:8443/__admin/; do sleep 1; done'
           docker container rm -f test
-
-          if [ "${{ matrix.versions.CONTEXT }}" != "alpine" ]
-          then
-            # helloworld
-            docker buildx build --tag wiremock-hello --load samples/hello --file samples/hello/Dockerfile-nightly
-            docker container run -d --name test -p 8080:8080 wiremock-hello
-            timeout 10 bash -c 'while ! curl --fail http://localhost:8080/hello; do sleep 1; done'
-            docker container rm -f test
-
-            # random
-            docker buildx build --tag wiremock-random --load samples/random --file samples/random/Dockerfile-nightly
-            docker container run -d --name test -p 8080:8080 wiremock-random
-            timeout 10 bash -c 'while ! curl --fail http://localhost:8080/random; do sleep 1; done'
-            docker container rm -f test
-          fi
 
       - name: Push Wiremock Docker image
         uses: docker/build-push-action@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:11.0.19_7-jre
 
 LABEL maintainer="Rodolphe CHAIGNEAU <rodolphe.chaigneau@gmail.com>"
 
-ARG WIREMOCK_VERSION=2.35.0-1
+ARG WIREMOCK_VERSION=2.35.0
 ENV WIREMOCK_VERSION $WIREMOCK_VERSION
 ENV GOSU_VERSION 1.14
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:11.0.19_7-jre-alpine
 
 LABEL maintainer="Rodolphe CHAIGNEAU <rodolphe.chaigneau@gmail.com>"
 
-ARG WIREMOCK_VERSION=2.35.0-1
+ARG WIREMOCK_VERSION=2.35.0
 ENV WIREMOCK_VERSION $WIREMOCK_VERSION
 
 WORKDIR /home/wiremock

--- a/test/integration-tests/pom.xml
+++ b/test/integration-tests/pom.xml
@@ -19,7 +19,7 @@
     <java.version>11</java.version>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.compiler.source>${java.version}</maven.compiler.source>
-    <wiremock-testcontainers.version>1.0-alpha-5</wiremock-testcontainers.version>
+    <wiremock-testcontainers.version>1.0-alpha-6</wiremock-testcontainers.version>
     <testcontainers.version>1.18.3</testcontainers.version>
     <junit.version>5.9.3</junit.version>
     <assertj.version>3.24.2</assertj.version>

--- a/test/integration-tests/src/test/java/org/wiremock/docker/it/SmokeTest.java
+++ b/test/integration-tests/src/test/java/org/wiremock/docker/it/SmokeTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SmokeTest {
 
   @Container
-  public WireMockContainer wiremockServer = new WireMockContainer(TestConfig.WIREMOCK_IMAGE_TAG)
+  public WireMockContainer wiremockServer = new WireMockContainer(TestConfig.WIREMOCK_IMAGE)
     .withMapping("hello", SmokeTest.class, "hello-world.json")
     .withMapping("hello-resource", SmokeTest.class, "hello-world-resource.json")
     .withFileFromResource("hello-world-resource-response.xml", SmokeTest.class,

--- a/test/integration-tests/src/test/java/org/wiremock/docker/it/TestConfig.java
+++ b/test/integration-tests/src/test/java/org/wiremock/docker/it/TestConfig.java
@@ -12,8 +12,8 @@ public class TestConfig {
   /**
    * Docker image tag to be used for testing.
    */
-  public static String WIREMOCK_IMAGE_TAG =
-    System.getProperty("it.wiremock-version", "2.35.0");
+  public static String WIREMOCK_IMAGE =
+    System.getProperty("it.wiremock-image", "wiremock/wiremock:2.35.0");
 
   public static String SAMPLES_DIR =
     System.getProperty("it.samples-path", "../../samples");

--- a/test/integration-tests/src/test/java/org/wiremock/docker/it/samples/AbtsractSampleTest.java
+++ b/test/integration-tests/src/test/java/org/wiremock/docker/it/samples/AbtsractSampleTest.java
@@ -27,8 +27,8 @@ public abstract class AbtsractSampleTest {
   //TODO: Simplify API once WireMock container is amended
   public WireMockContainer createWireMockContainer(boolean useHttps) {
     final WireMockContainer wiremockServer = useHttps
-      ? new WireMockHttpsContainer(TestConfig.WIREMOCK_IMAGE_TAG)
-      : new WireMockContainer(TestConfig.WIREMOCK_IMAGE_TAG);
+      ? new WireMockHttpsContainer(TestConfig.WIREMOCK_IMAGE)
+      : new WireMockContainer(TestConfig.WIREMOCK_IMAGE);
 
     // TODO: Move to the WireMock Module
     try {


### PR DESCRIPTION
Increases test coverage for the builds and makes them more reliable
