### PR TITLE
Remove broken DockerHub description updater from the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,11 +134,3 @@ jobs:
         with:
           tag_name: ${{ needs.check-new-version.outputs.new_version }}
 
-      - name: DockerHub Description
-        uses: peter-evans/dockerhub-description@v2
-        with:
-          username: wiremockbot
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          repository: wiremock/wiremock
-          short-description: Official images for the WireMock standalone server
-          readme-filepath: ./readme.md


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
