### PR TITLE
Create release Pipeline for 2.x

### DIFF
--- a/.github/workflows/release-2.x.yml
+++ b/.github/workflows/release-2.x.yml
@@ -1,0 +1,132 @@
+name: Release 2.x
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Image version (single-digit suffix like 2.35.0-1)'
+        required: true
+        default: 1
+      bundled-version:
+        description: 'Bundled WireMock version'
+        required: true
+        default: 2.35.1
+
+jobs:
+
+  check-new-version:
+    runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ steps.new_version.outputs.NEW_VERSION }}
+    steps:
+
+      - name: Release if newer version
+        id: new_version
+        run: |
+          CURRENT_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/wiremock/wiremock-docker.git '2.*.*' | tail -1 | cut -d '/' -f3)
+          CURRENT_VERSION=${CURRENT_VERSION%-*}
+          LATEST_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/wiremock/wiremock.git '2.*.*' | tail -1 | cut -d '/' -f3)
+          echo "NEW_VERSION=${{ github.event.inputs.bundled-version }}-${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+
+  docker-build-push:
+    runs-on: ubuntu-latest
+    needs: [check-new-version]
+    if: needs.check-new-version.outputs.new_version
+    strategy:
+      matrix:
+        versions:
+          - CONTEXT: .
+            IMAGES:
+              - wiremock/wiremock:${{ needs.check-new-version.outputs.new_version }}
+              - ghcr.io/wiremock/wiremock:${{ needs.check-new-version.outputs.new_version }}
+            PLATFORMS:
+              - linux/amd64
+              - linux/arm64
+              - linux/arm/v7
+          - CONTEXT: alpine
+            IMAGES:
+              - wiremock/wiremock:${{ needs.check-new-version.outputs.new_version }}-alpine
+              - ghcr.io/wiremock/wiremock:${{ needs.check-new-version.outputs.new_version }}-alpine
+            PLATFORMS:
+              - linux/amd64
+    steps:
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        if: ${{ matrix.versions.CONTEXT != 'alpine' }}
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Checkout sources
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 0
+          ref: 2.x
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: wiremockbot
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: wiremock
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push WireMock Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: ${{ matrix.versions.CONTEXT }}
+          platforms: ${{ join(matrix.versions.PLATFORMS, ',') }}
+          push: true
+          tags: ${{ join(matrix.versions.IMAGES, ',') }}
+          build-args: |
+            "WIREMOCK_VERSION=${{ github.event.inputs.bundled-version }}"
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [docker-build-push, check-new-version]
+    steps:
+
+      - name: Checkout sources
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 0
+          ref: "2.x"
+
+      - name: Update version
+        run: |
+          # Replace version in readme.md
+          LAST_VERSION=$(git describe --tag --abbrev=0)
+          LAST_MINOR_VERSION=${LAST_VERSION%.*}
+          NEW_VERSION=${{ needs.check-new-version.outputs.new_version }}
+          NEW_MINOR_VERSION=${NEW_VERSION%.*}
+          sed -i s/${LAST_VERSION}/${NEW_VERSION}/g readme.md
+          sed -i s/${LAST_MINOR_VERSION}/${NEW_MINOR_VERSION}/g readme.md
+
+          # Replace version in Dockerfiles
+          LAST_VERSION=${LAST_VERSION%-*}
+          sed -i s/${LAST_VERSION}/${NEW_VERSION}/g Dockerfile alpine/Dockerfile
+
+          # Push update
+          git config --local user.name "wiremockbot"
+          git config --local user.email "release-bot@wiremock.org"
+          git add .
+          git commit -m "upgrade to version ${NEW_VERSION}"
+          git remote set-url origin https://${{ secrets.GITHUB_TOKEN }}@github.com/wiremock/wiremock-docker.git
+          git push origin 2.x
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ needs.check-new-version.outputs.new_version }}
+          target_commitish: "2.x"


### PR DESCRIPTION
Subj - experimental for 2.35.1-1
## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
