### PR TITLE
Update to WireMock 3.1.0 + Fix version matching in the release pipelines

### DIFF
--- a/.github/workflows/release-2.x.yml
+++ b/.github/workflows/release-2.x.yml
@@ -115,7 +115,7 @@ jobs:
 
           # Replace version in Dockerfiles
           LAST_VERSION=${LAST_VERSION%-*}
-          sed -i 's/ARG WIREMOCK_VERSION=.*/ARG WIREMOCK_VERSION=${ github.event.inputs.bundled-version }/g' Dockerfile alpine/Dockerfile
+          sed -i 's/ARG WIREMOCK_VERSION=.*/ARG WIREMOCK_VERSION=${{ github.event.inputs.bundled-version }}/g' Dockerfile alpine/Dockerfile
 
           # Push update
           git config --local user.name "wiremockbot"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
           push: true
           tags: ${{ join(matrix.versions.IMAGES, ',') }}
           build-args: |
-            WIREMOCK_VERSION=${{ github.event.inputs.bundled-version }}
+            "WIREMOCK_VERSION=${{ github.event.inputs.bundled-version }}"
 
   release:
     runs-on: ubuntu-latest
@@ -119,7 +119,7 @@ jobs:
 
           # Replace version in Dockerfiles
           LAST_VERSION=${LAST_VERSION%-*}
-          sed -i 's/ARG WIREMOCK_VERSION=.*/ARG WIREMOCK_VERSION=${ github.event.inputs.bundled-version }/g' Dockerfile alpine/Dockerfile
+          sed -i 's/ARG WIREMOCK_VERSION=.*/ARG WIREMOCK_VERSION=${{ github.event.inputs.bundled-version }}/g' Dockerfile alpine/Dockerfile
 
           # Push update
           git config --local user.name "wiremockbot"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:11.0.20_8-jre
 
 LABEL maintainer="Rodolphe CHAIGNEAU <rodolphe.chaigneau@gmail.com>"
 
-ARG WIREMOCK_VERSION=${ github.event.inputs.bundled-version }
+ARG WIREMOCK_VERSION=3.1.0
 ENV WIREMOCK_VERSION $WIREMOCK_VERSION
 ENV GOSU_VERSION 1.14
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:11.0.20_8-jre-alpine
 
 LABEL maintainer="Rodolphe CHAIGNEAU <rodolphe.chaigneau@gmail.com>"
 
-ARG WIREMOCK_VERSION=${ github.event.inputs.bundled-version }
+ARG WIREMOCK_VERSION=3.1.0
 ENV WIREMOCK_VERSION $WIREMOCK_VERSION
 
 WORKDIR /home/wiremock


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
