### PR TITLE
Add integration test for the webhooks extension

### DIFF
--- a/test/integration-tests/src/test/java/org/wiremock/docker/it/TestConfig.java
+++ b/test/integration-tests/src/test/java/org/wiremock/docker/it/TestConfig.java
@@ -13,10 +13,15 @@ public class TestConfig {
    * Docker image tag to be used for testing.
    */
   public static String WIREMOCK_IMAGE =
-    System.getProperty("it.wiremock-image", "wiremock/wiremock:2.35.0");
+    System.getProperty("it.wiremock-image", "wiremock/wiremock:3.1.0-1");
 
   public static String SAMPLES_DIR =
     System.getProperty("it.samples-path", "../../samples");
+
+  public static boolean isWebkooksExtensionEmbedded() {
+    // TODO Fixme
+    return true;
+  }
 
   public static Path getSamplesPath() {
     return new File(SAMPLES_DIR).toPath();

--- a/test/integration-tests/src/test/java/org/wiremock/docker/it/extensions/WireMockContainerExtensionsWebhookTest.java
+++ b/test/integration-tests/src/test/java/org/wiremock/docker/it/extensions/WireMockContainerExtensionsWebhookTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2023 WireMock Inc, Oleg Nenashev and all project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wiremock.docker.it.extensions;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.wiremock.docker.it.TestConfig;
+import org.wiremock.docker.it.util.HttpResponse;
+import org.wiremock.docker.it.util.TestHttpClient;
+import org.wiremock.docker.it.util.TestHttpServer;
+import org.wiremock.integrations.testcontainers.WireMockContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testcontainers.Testcontainers.exposeHostPorts;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.Collections;
+
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+/**
+ * Tests the WireMock Webhook extension and TestContainers Networking
+ * For this type of tests we should use following steps:
+ * <p>
+ * Use {@link GenericContainer#withAccessToHost(boolean)} to force the host access mechanism
+ * <p>
+ * Use {@link org.testcontainers.Testcontainers#exposeHostPorts(int...)} to expose host machine ports to containers
+ * <p>
+ * Use {@link GenericContainer#INTERNAL_HOST_HOSTNAME} to calculate hostname for callback
+ *
+ * @see <a href="https://www.testcontainers.org/features/networking/">Testcontainers Networking</a>
+ */
+@Testcontainers
+class WireMockContainerExtensionsWebhookTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WireMockContainerExtensionsWebhookTest.class);
+    private static final String WIREMOCK_PATH = "/wiremock/callback-trigger";
+    private static final String APPLICATION_PATH = "/application/callback-receiver";
+
+    public static String WEBHOOKS_VERSION="3.0.1";
+
+    TestHttpServer applicationServer = TestHttpServer.newInstance();
+
+    @Container
+    WireMockContainer wiremockServer = new WireMockContainer(TestConfig.WIREMOCK_IMAGE)
+            .withLogConsumer(new Slf4jLogConsumer(LOGGER))
+            .withCliArg("--global-response-templating")
+            .withMapping("webhook-callback-template", WireMockContainerExtensionsWebhookTest.class,
+              "webhook-callback-template.json")
+            .withExtension("org.wiremock.webhooks.Webhooks")
+            .withAccessToHost(true); // Force the host access mechanism
+
+    @Test
+    void callbackUsingJsonStub() throws Exception {
+        // given
+        exposeHostPorts(applicationServer.getPort()); // Exposing host ports to the container
+
+        String wiremockUrl = wiremockServer.getUrl(WIREMOCK_PATH);
+        String applicationCallbackUrl = String.format("http://%s:%d%s", GenericContainer.INTERNAL_HOST_HOSTNAME, applicationServer.getPort(), APPLICATION_PATH);
+
+        // when
+        HttpResponse response = new TestHttpClient().post(
+                wiremockUrl,
+                "{\"callbackMethod\": \"PUT\", \"callbackUrl\": \"" + applicationCallbackUrl + "\"}"
+        );
+
+        // then
+        assertThat(response).as("Wiremock Response").isNotNull().satisfies(it -> {
+            assertThat(it.getStatusCode()).as("Wiremock Response Status").isEqualTo(200);
+            assertThat(it.getBody()).as("Wiremock Response Body")
+                    .contains("Please wait callback")
+                    .contains("PUT")
+                    .contains(applicationCallbackUrl);
+        });
+
+        await().atMost(Duration.ofMillis(5000)).untilAsserted(() -> {
+            assertThat(applicationServer.getRecordedRequests()).as("Received Callback")
+                    .hasSize(1)
+                    .first().usingRecursiveComparison()
+                    .isEqualTo(new TestHttpServer.RecordedRequest("PUT", APPLICATION_PATH, "Async processing Finished"));
+        });
+    }
+}

--- a/test/integration-tests/src/test/java/org/wiremock/docker/it/util/HttpResponse.java
+++ b/test/integration-tests/src/test/java/org/wiremock/docker/it/util/HttpResponse.java
@@ -1,0 +1,19 @@
+package org.wiremock.docker.it.util;
+
+public class HttpResponse {
+
+    String body;
+    int statusCode;
+    public HttpResponse(String body, int statusCode) {
+        this.body = body;
+        this.statusCode = statusCode;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+}

--- a/test/integration-tests/src/test/java/org/wiremock/docker/it/util/TestHttpClient.java
+++ b/test/integration-tests/src/test/java/org/wiremock/docker/it/util/TestHttpClient.java
@@ -1,0 +1,56 @@
+package org.wiremock.docker.it.util;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+public final class TestHttpClient {
+
+    public HttpResponse send(HttpURLConnection connection) throws IOException {
+        InputStream inputStream = connection.getInputStream();
+
+        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+        StringBuilder response = new StringBuilder();
+
+        String line;
+        while ((line = reader.readLine()) != null) {
+            response.append(line);
+        }
+        reader.close();
+
+
+
+        return new HttpResponse(response.toString(), connection.getResponseCode());
+    }
+
+    public HttpResponse get(String uri) throws IOException {
+        URL url = new URL(uri);
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestMethod("GET");
+
+        return send(connection);
+    }
+
+
+    public HttpResponse post(String uri, String body) throws IOException {
+        URL url = new URL(uri);
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestMethod("POST");
+        connection.setRequestProperty("Content-Type", "application/json");
+        connection.setRequestProperty("Accept", "application/json");
+        connection.setDoOutput(true);
+        connection.setConnectTimeout(10000);
+
+        try (OutputStream outputStream = connection.getOutputStream()) {
+            byte[] input = body.getBytes(StandardCharsets.UTF_8);
+            outputStream.write(input, 0, input.length);
+        }
+
+        return send(connection);
+    }
+}

--- a/test/integration-tests/src/test/java/org/wiremock/docker/it/util/TestHttpServer.java
+++ b/test/integration-tests/src/test/java/org/wiremock/docker/it/util/TestHttpServer.java
@@ -1,0 +1,105 @@
+package org.wiremock.docker.it.util;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestHttpServer {
+    private final HttpServer server;
+    private final AllRequestsRecorder handler;
+
+    public static TestHttpServer newInstance() {
+        try {
+            return new TestHttpServer(0);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to start Test Http Server", e);
+        }
+    }
+
+    private TestHttpServer(int port) throws IOException {
+        // handlers
+        handler = new AllRequestsRecorder();
+        // server
+        server = HttpServer.create(new InetSocketAddress(port), 0);
+        server.createContext("/", handler);
+        server.start();
+    }
+
+    public int getPort() {
+        return server.getAddress().getPort();
+    }
+
+    public List<RecordedRequest> getRecordedRequests() {
+        return handler.getRecordedRequests();
+    }
+
+
+    private static final class AllRequestsRecorder implements HttpHandler {
+
+        private final List<RecordedRequest> recordedRequests = new ArrayList<>();
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            String method = exchange.getRequestMethod();
+            String path = exchange.getRequestURI().getPath();
+            String body = null;
+
+            InputStream requestBody = exchange.getRequestBody();
+            if (requestBody.available() > 0) {
+                byte[] requestBodyBytes = new byte[requestBody.available()];
+                requestBody.read(requestBodyBytes);
+                body = new String(requestBodyBytes, StandardCharsets.UTF_8);
+            }
+
+            recordedRequests.add(new RecordedRequest(method, path, body));
+
+            exchange.sendResponseHeaders(200, 0);
+            exchange.getResponseBody().close();
+        }
+
+        public List<RecordedRequest> getRecordedRequests() {
+            return recordedRequests;
+        }
+    }
+
+    public static final class RecordedRequest {
+        private final String method;
+        private final String path;
+        private final String body;
+
+        public RecordedRequest(String method, String path, String body) {
+            this.method = method;
+            this.path = path;
+            this.body = body;
+        }
+
+        public String getMethod() {
+            return method;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public String getBody() {
+            return body;
+        }
+
+        @Override
+        public String toString() {
+            return "RecordedRequest{" +
+                    "method='" + method + '\'' +
+                    ", path='" + path + '\'' +
+                    ", body='" + body + '\'' +
+                    '}';
+        }
+
+    }
+}

--- a/test/integration-tests/src/test/resources/org/wiremock/docker/it/extensions/WireMockContainerExtensionsWebhookTest/webhook-callback-template.json
+++ b/test/integration-tests/src/test/resources/org/wiremock/docker/it/extensions/WireMockContainerExtensionsWebhookTest/webhook-callback-template.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/wiremock/callback-trigger"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "message": "Please wait callback",
+      "method": "{{jsonPath request.body '$.callbackMethod'}}",
+      "url": "{{jsonPath request.body '$.callbackUrl'}}"
+    }
+  },
+  "postServeActions": [
+    {
+      "name": "webhook",
+      "parameters": {
+        "method": "{{jsonPath originalRequest.body '$.callbackMethod'}}",
+        "url": "{{jsonPath originalRequest.body '$.callbackUrl'}}",
+        "body": "Async processing Finished",
+        "delay": {
+          "type": "fixed",
+          "milliseconds": 1000
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Just for test and demo

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] Recommended: If you participate in Hacktoberfest 2023, maake sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
