### PR TITLE
#78 - Add support for WireMock CLI options as environment variable

### DIFF
--- a/alpine/docker-entrypoint.sh
+++ b/alpine/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 # Set `java` command if needed
 if [ "$1" = "" -o "${1#-}" != "$1" ]; then
-  set -- java $JAVA_OPTS -cp /var/wiremock/lib/*:/var/wiremock/extensions/* wiremock.Run "$@"
+  set -- java $JAVA_OPTS -cp /var/wiremock/lib/*:/var/wiremock/extensions/* wiremock.Run "$@" $WIREMOCK_OPTIONS
 fi
 
 # allow the container to be started with `-e uid=`
@@ -12,7 +12,7 @@ if [ "$uid" != "" ]; then
   # Change the ownership of /home/wiremock to $uid
   chown -R $uid:$uid /home/wiremock
 
-  set -- su-exec $uid:$uid "$@"
+  set -- su-exec $uid:$uid "$@"  $WIREMOCK_OPTIONS
 fi
 
-exec "$@"
+exec "$@"  $WIREMOCK_OPTIONS

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,15 +4,14 @@ set -e
 
 # Set `java` command if needed
 if [ "$1" = "" -o "${1:0:1}" = "-" ]; then
-  set -- java $JAVA_OPTS -cp /var/wiremock/lib/*:/var/wiremock/extensions/* wiremock.Run "$@"
+  set -- java $JAVA_OPTS -cp /var/wiremock/lib/*:/var/wiremock/extensions/* wiremock.Run "$@"  $WIREMOCK_OPTIONS
 fi
 
 # allow the container to be started with `-e uid=`
 if [ "$uid" != "" ]; then
   # Change the ownership of /home/wiremock to $uid
   chown -R $uid:$uid /home/wiremock
-
-  set -- gosu $uid:$uid "$@"
+  set -- gosu $uid:$uid "$@" $WIREMOCK_OPTIONS
 fi
 
-exec "$@"
+exec "$@" $WIREMOCK_OPTIONS

--- a/test/integration-tests/src/test/java/org/wiremock/docker/it/WireMockOptionsTest.java
+++ b/test/integration-tests/src/test/java/org/wiremock/docker/it/WireMockOptionsTest.java
@@ -30,7 +30,7 @@ class WireMockOptionsTest {
     .withEnv("WIREMOCK_OPTIONS", "--verbose");
 
   @Test
-  public void checkIfVerboseEnabledInLogs() {
+  public void checkVerboseEnablingLogLine() {
     assertTrue(wiremockServer.getLogs().contains("Verbose logging enabled"));
   }
 }

--- a/test/integration-tests/src/test/java/org/wiremock/docker/it/WireMockOptionsTest.java
+++ b/test/integration-tests/src/test/java/org/wiremock/docker/it/WireMockOptionsTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023 WireMock Inc, Oleg Nenashev and all project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wiremock.docker.it;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import org.wiremock.integrations.testcontainers.WireMockContainer;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Testcontainers
+class WireMockOptionsTest {
+
+  @Container
+  public WireMockContainer wiremockServer = new WireMockContainer(TestConfig.WIREMOCK_IMAGE)
+    .withEnv("WIREMOCK_OPTIONS", "--verbose");
+
+  @Test
+  public void checkIfVerboseEnabledInLogs() {
+    assertTrue(wiremockServer.getLogs().contains("Verbose logging enabled"));
+  }
+}


### PR DESCRIPTION
This PR adds option to pass wiremock options as env variable to docker file and use it from helm chart.

## References
Resolves - https://github.com/wiremock/wiremock-docker/issues/78

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
