### PR TITLE
Fix WIREMOCK_OPTIONS duplicated

### DIFF
--- a/alpine/docker-entrypoint.sh
+++ b/alpine/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 # Set `java` command if needed
 if [ "$1" = "" -o "${1#-}" != "$1" ]; then
-  set -- java $JAVA_OPTS -cp /var/wiremock/lib/*:/var/wiremock/extensions/* wiremock.Run "$@" $WIREMOCK_OPTIONS
+  set -- java $JAVA_OPTS -cp /var/wiremock/lib/*:/var/wiremock/extensions/* wiremock.Run "$@"
 fi
 
 # allow the container to be started with `-e uid=`
@@ -12,7 +12,7 @@ if [ "$uid" != "" ]; then
   # Change the ownership of /home/wiremock to $uid
   chown -R $uid:$uid /home/wiremock
 
-  set -- su-exec $uid:$uid "$@"  $WIREMOCK_OPTIONS
+  set -- su-exec $uid:$uid "$@"
 fi
 
 exec "$@"  $WIREMOCK_OPTIONS

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,14 +4,14 @@ set -e
 
 # Set `java` command if needed
 if [ "$1" = "" -o "${1:0:1}" = "-" ]; then
-  set -- java $JAVA_OPTS -cp /var/wiremock/lib/*:/var/wiremock/extensions/* wiremock.Run "$@"  $WIREMOCK_OPTIONS
+  set -- java $JAVA_OPTS -cp /var/wiremock/lib/*:/var/wiremock/extensions/* wiremock.Run "$@"
 fi
 
 # allow the container to be started with `-e uid=`
 if [ "$uid" != "" ]; then
   # Change the ownership of /home/wiremock to $uid
   chown -R $uid:$uid /home/wiremock
-  set -- gosu $uid:$uid "$@" $WIREMOCK_OPTIONS
+  set -- gosu $uid:$uid "$@"
 fi
 
 exec "$@" $WIREMOCK_OPTIONS


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References

Bug: https://github.com/wiremock/wiremock-docker/issues/91

When passing the wiremock options sometimes fail. This is due the WIREMOCK_OPTIONS being duplicated. I've tested it in the entry point.sh adding -x for tracing.
```
❯ docker run -e WIREMOCK_OPTIONS='--container-threads=100 --verbose' wiremock/wiremock:test-opts
+ '[' '' = '' -o '' = - ']'
+ set -- java -cp '/var/wiremock/lib/*:/var/wiremock/extensions/*' wiremock.Run --container-threads=100 --verbose
+ '[' '' '!=' '' ']'
+ exec java -cp '/var/wiremock/lib/*:/var/wiremock/extensions/*' wiremock.Run --container-threads=100 --verbose --container-threads=100 --verbose
2023-10-20 09:25:02.700 Verbose logging enabled
Exception in thread "main" 
Exception: java.util.MissingResourceException thrown from the UncaughtExceptionHandler in thread "main"
```

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
