### PR TITLE
Enable container output logging in tests

### DIFF
--- a/test/integration-tests/pom.xml
+++ b/test/integration-tests/pom.xml
@@ -22,6 +22,7 @@
     <wiremock-testcontainers.version>1.0-alpha-7</wiremock-testcontainers.version>
     <testcontainers.version>1.18.3</testcontainers.version>
     <junit.version>5.9.3</junit.version>
+    <slf4j.version>2.0.7</slf4j.version>
     <assertj.version>3.24.2</assertj.version>
     <awaitility.version>4.2.0</awaitility.version>
     <project.scm.id>github</project.scm.id>
@@ -54,7 +55,7 @@
         <!-- Fix dependency convergence [logback-classic vs junit] -->
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>2.0.7</version>
+        <version>${slf4j.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -101,14 +102,13 @@
       <artifactId>awaitility</artifactId>
       <version>${awaitility.version}</version>
       <scope>test</scope>
-    </dependency> <!--
+    </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.3.7</version>
-      <scope>provided</scope>
-      <optional>true</optional>
-    </dependency> -->
+      <version>1.4.7</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/test/integration-tests/src/test/java/org/wiremock/docker/it/TestConfig.java
+++ b/test/integration-tests/src/test/java/org/wiremock/docker/it/TestConfig.java
@@ -13,7 +13,7 @@ public class TestConfig {
    * Docker image tag to be used for testing.
    */
   public static String WIREMOCK_IMAGE =
-    System.getProperty("it.wiremock-image", "wiremock/wiremock:3.1.0-1");
+    System.getProperty("it.wiremock-image", "wiremock/wiremock:test");
 
   public static String SAMPLES_DIR =
     System.getProperty("it.samples-path", "../../samples");

--- a/test/integration-tests/src/test/java/org/wiremock/docker/it/extensions/WireMockContainerExtensionsWebhookTest.java
+++ b/test/integration-tests/src/test/java/org/wiremock/docker/it/extensions/WireMockContainerExtensionsWebhookTest.java
@@ -15,6 +15,7 @@
  */
 package org.wiremock.docker.it.extensions;
 
+import org.junit.Before;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,6 +62,7 @@ class WireMockContainerExtensionsWebhookTest {
     public static String WEBHOOKS_VERSION="3.0.1";
 
     TestHttpServer applicationServer = TestHttpServer.newInstance();
+    Slf4jLogConsumer logConsumer = new Slf4jLogConsumer(LOGGER);
 
     @Container
     WireMockContainer wiremockServer = new WireMockContainer(TestConfig.WIREMOCK_IMAGE)
@@ -70,6 +72,11 @@ class WireMockContainerExtensionsWebhookTest {
               "webhook-callback-template.json")
             .withExtension("org.wiremock.webhooks.Webhooks")
             .withAccessToHost(true); // Force the host access mechanism
+
+    @Before
+    public void setupLogging() {
+      wiremockServer.followOutput(logConsumer);
+    }
 
     @Test
     void callbackUsingJsonStub() throws Exception {

--- a/test/integration-tests/src/test/resources/logback-test.xml
+++ b/test/integration-tests/src/test/resources/logback-test.xml
@@ -1,5 +1,8 @@
-<configuration>
+<configuration name="WireMock Docker Integration Tests" status="info">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+          <level>INFO</level>
+        </filter>
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
         </encoder>


### PR DESCRIPTION
Need it to diagnose the CI failures in the `main` branch