### PR TITLE
Stop passing the Webhooks extension classpath for WireMock 3.x in tests

### DIFF
--- a/test/integration-tests/pom.xml
+++ b/test/integration-tests/pom.xml
@@ -146,12 +146,7 @@
                 <dependency>
                   <groupId>org.wiremock</groupId>
                   <artifactId>wiremock-webhooks-extension</artifactId>
-                  <version>2.35.0</version>
-                </dependency>
-                <dependency>
-                  <groupId>org.wiremock</groupId>
-                  <artifactId>wiremock-webhooks-extension</artifactId>
-                  <version>3.0.0</version>
+                  <version>2.35.1</version>
                 </dependency>
               </artifactItems>
               <outputDirectory>${project.build.directory}/test-wiremock-extension</outputDirectory>

--- a/test/integration-tests/src/test/java/org/wiremock/docker/it/extensions/WireMockContainerExtensionsWebhookTest.java
+++ b/test/integration-tests/src/test/java/org/wiremock/docker/it/extensions/WireMockContainerExtensionsWebhookTest.java
@@ -59,8 +59,6 @@ class WireMockContainerExtensionsWebhookTest {
     private static final String WIREMOCK_PATH = "/wiremock/callback-trigger";
     private static final String APPLICATION_PATH = "/application/callback-receiver";
 
-    public static String WEBHOOKS_VERSION="3.0.1";
-
     TestHttpServer applicationServer = TestHttpServer.newInstance();
     Slf4jLogConsumer logConsumer = new Slf4jLogConsumer(LOGGER);
 
@@ -70,7 +68,8 @@ class WireMockContainerExtensionsWebhookTest {
             .withCliArg("--global-response-templating")
             .withMapping("webhook-callback-template", WireMockContainerExtensionsWebhookTest.class,
               "webhook-callback-template.json")
-            .withExtension("org.wiremock.webhooks.Webhooks")
+      // No longer needed and leads to crash on 3.3.1
+      //   .withExtension("org.wiremock.webhooks.Webhooks")
             .withAccessToHost(true); // Force the host access mechanism
 
     @Before


### PR DESCRIPTION
The current implementation will crash, because of `java.lang.NoSuchMethodException: org.wiremock.webhooks.Webhooks.<init>()`

```
11:20:23.154 [docker-java-stream-1319901105] INFO  org.wiremock.docker.it.extensions.WireMockContainerExtensionsWebhookTest - STDERR: Exception in thread "main" java.lang.NoSuchMethodException: org.wiremock.webhooks.Webhooks.<init>()
11:20:23.155 [docker-java-stream-1319901105] INFO  org.wiremock.docker.it.extensions.WireMockContainerExtensionsWebhookTest - STDERR: 	at java.base/java.lang.Class.getConstructor0(Unknown Source)
11:20:23.155 [docker-java-stream-1319901105] INFO  org.wiremock.docker.it.extensions.WireMockContainerExtensionsWebhookTest - STDERR: 	at java.base/java.lang.Class.getDeclaredConstructor(Unknown Source)
11:20:23.155 [docker-java-stream-1319901105] INFO  org.wiremock.docker.it.extensions.WireMockContainerExtensionsWebhookTest - STDERR: 	at com.github.tomakehurst.wiremock.extension.Extensions.load(Extensions.java:226)
11:20:23.155 [docker-java-stream-1319901105] INFO  org.wiremock.docker.it.extensions.WireMockContainerExtensionsWebhookTest - STDERR: 	at java.base/java.util.stream.ReferencePipeline$3$1.accept(Unknown Source)
11:20:23.155 [docker-java-stream-1319901105] INFO  org.wiremock.docker.it.extensions.WireMockContainerExtensionsWebhookTest - STDERR: 	at java.base/java.util.stream.ReferencePipeline$3$1.accept(Unknown Source)
11:20:23.155 [docker-java-stream-1319901105] INFO  org.wiremock.docker.it.extensions.WireMockContainerExtensionsWebhookTest - STDERR: 	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(Unknown Source)
11:20:23.155 [docker-java-stream-1319901105] INFO  org.wiremock.docker.it.extensions.WireMockContainerExtensionsWebhookTest - STDERR: 	at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)
11:20:23.155 [docker-java-stream-1319901105] INFO  org.wiremock.docker.it.extensions.WireMockContainerExtensionsWebhookTest - STDERR: 	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
11:20:23.155 [docker-java-stream-1319901105] INFO  org.wiremock.docker.it.extensions.WireMockContainerExtensionsWebhookTest - STDERR: 	at java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(Unknown Source)
11:20:23.155 [docker-java-stream-1319901105] INFO  org.wiremock.docker.it.extensions.WireMockContainerExtensionsWebhookTest - STDERR: 	at java.base/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Unknown Source)
11:20:23.155 [docker-java-stream-1319901105] INFO  org.wiremock.docker.it.extensions.WireMockContainerExtensionsWebhookTest - STDERR: 	at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)
11:20:23.155 [docker-java-stream-1319901105] INFO  org.wiremock.docker.it.extensions.WireMockContainerExtensionsWebhookTest - STDERR: 	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
11:20:23.156 [docker-java-stream-1319901105] INFO  org.wiremock.docker.it.extensions.WireMockContainerExtensionsWebhookTest - STDERR: 	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(Unknown Source)
11:20:23.156 [docker-java-stream-1319901105] INFO  org.wiremock.docker.it.extensions.WireMockContainerExtensionsWebhookTest - STDERR: 	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(Unknown Source)
11:20:23.156 [docker-java-stream-1319901105] INFO  org.wiremock.docker.it.extensions.WireMockContainerExtensionsWebhookTest - STDERR: 	at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)
11:20:23.156 [docker-java-stream-1319901105] INFO  org.wiremock.docker.it.extensions.WireMockContainerExtensionsWebhookTest - STDERR: 	at java.base/java.util.stream.ReferencePipeline.forEach(Unknown Source)
11:20:23.156 [docker-java-stream-1319901105] INFO  org.wiremock.docker.it.extensions.WireMockContainerExtensionsWebhookTest - STDERR: 	at com.github.tomakehurst.wiremock.extension.Extensions.load(Extensions.java:77)
11:20:23.156 [docker-java-stream-1319901105] INFO  org.wiremock.docker.it.extensions.WireMockContainerExtensionsWebhookTest - STDERR: 	at com.github.tomakehurst.wiremock.core.WireMockApp.<init>(WireMockApp.java:94)
11:20:23.156 [docker-java-stream-1319901105] INFO  org.wiremock.docker.it.extensions.WireMockContainerExtensionsWebhookTest - STDERR: 	at com.github.tomakehurst.wiremock.WireMockServer.<init>(WireMockServer.java:71)
11:20:23.156 [docker-java-stream-1319901105] INFO  org.wiremock.docker.it.extensions.WireMockContainerExtensionsWebhookTest - STDERR: 	at com.github.tomakehurst.wiremock.standalone.WireMockServerRunner.run(WireMockServerRunner.java:66)
11:20:23.156 [docker-java-stream-1319901105] INFO  org.wiremock.docker.it.extensions.WireMockContainerExtensionsWebhookTest - STDERR: 	at wiremock.Run.main(Run.java:23)
11:21:22.844 [main] ERROR tc.wiremock/wiremock:test-alpine - Could not start container
```