### PR TITLE
Add Arm images build to  CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,7 @@ jobs:
               - wiremock/wiremock:test-alpine
             PLATFORMS:
               - linux/amd64
-              - linux/arm64
-              - linux/arm/v7
+
     steps:
       
       - name: Set up QEMU

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           context: ${{ matrix.versions.CONTEXT }}
           platforms: ${{ join(matrix.versions.PLATFORMS, ',') }}
-          load: true
+          push: false
           file: ${{ matrix.versions.CONTEXT }}/Dockerfile
           tags: ${{ matrix.versions.TAGS[0] }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ "main", "3.x" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "main", "3.x" ]
+    branches: [ "main" ]
   workflow_dispatch:
 
 jobs:
@@ -16,10 +16,25 @@ jobs:
           - CONTEXT: .
             TAGS:
               - wiremock/wiremock:test
+            PLATFORMS:
+              - linux/amd64
+              - linux/arm64
+              - linux/arm/v7
           - CONTEXT: alpine
             TAGS:
               - wiremock/wiremock:test-alpine
+            PLATFORMS:
+              - linux/amd64
+              - linux/arm64
+              - linux/arm/v7
     steps:
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -33,10 +48,11 @@ jobs:
 #          username: wiremock
 #          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-      - name: Build Wiremock Docker image
+      - name: Build WireMock Docker image
         uses: docker/build-push-action@v4
         with:
           context: ${{ matrix.versions.CONTEXT }}
+          platforms: ${{ join(matrix.versions.PLATFORMS, ',') }}
           load: true
           file: ${{ matrix.versions.CONTEXT }}/Dockerfile
           tags: ${{ matrix.versions.TAGS[0] }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,6 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-        if: ${{ matrix.versions.CONTEXT != 'alpine' }}
         with:
           image: tonistiigi/binfmt:latest
           platforms: all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,6 @@ jobs:
               - ghcr.io/wiremock/wiremock:${{ needs.check-new-version.outputs.new_version }}-alpine
             PLATFORMS:
               - linux/amd64
-              - linux/arm64
-              - linux/arm/v7
     
     steps:
 


### PR DESCRIPTION
We do not run the integration tests but at least build the images now

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
