### PR TITLE
add HEALTHCHECK to dockerfiles.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,4 +57,6 @@ COPY docker-entrypoint.sh /
 
 EXPOSE 8080 8443
 
+HEALTHCHECK --start-period=5s --start-interval=100ms CMD curl -f http://localhost:8080/__admin/health || exit 1
+
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/Dockerfile-nightly
+++ b/Dockerfile-nightly
@@ -29,4 +29,6 @@ RUN mkdir -p /home/wiremock/mappings && \
 
 EXPOSE 8080 8443
 
+HEALTHCHECK --start-period=5s --start-interval=100ms CMD curl -f http://localhost:8080/__admin/health || exit 1
+
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ To verify the WireMock state,
 access [http://localhost:8080/__admin/health](http://localhost:8080/__admin/health) to display the health status and the information.
 The `/__admin/health` endpoint is available for WireMock 3.1.0 or above.
 
+A [HEALTHCHECK](https://docs.docker.com/reference/dockerfile/#healthcheck) is also built into the docker image to
+allow direct querying of the docker container's health status.
+Under the hood, this uses the same method as above to verify the status of the container.
+
 ## Configuring WireMock
 
 You can configure WireMock using the following ways:

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -27,4 +27,6 @@ COPY docker-entrypoint.sh /
 
 EXPOSE 8080 8443
 
+HEALTHCHECK --start-period=5s --start-interval=100ms CMD wget --no-verbose --tries=1 --spider http://localhost:8080/__admin/health || exit 1
+
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/alpine/Dockerfile-nightly
+++ b/alpine/Dockerfile-nightly
@@ -33,4 +33,6 @@ COPY docker-entrypoint.sh /
 
 EXPOSE 8080 8443
 
+HEALTHCHECK --start-period=5s --start-interval=100ms CMD wget --no-verbose --tries=1 --spider http://localhost:8080/__admin/health || exit 1
+
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/test/integration-tests/src/test/java/org/wiremock/docker/it/HealthTest.java
+++ b/test/integration-tests/src/test/java/org/wiremock/docker/it/HealthTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 WireMock Inc, Rafe Arnold and all project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wiremock.docker.it;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.wiremock.integrations.testcontainers.WireMockContainer;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HealthTest {
+
+  @Test
+  public void containerCanWaitForDockerHealthcheck() throws Exception {
+    try (WireMockContainer wiremockServer =
+           new WireMockContainer(TestConfig.WIREMOCK_IMAGE).waitingFor(Wait.forHealthcheck())) {
+      wiremockServer.start();
+      final HttpClient client = HttpClient.newHttpClient();
+      final HttpRequest request = HttpRequest.newBuilder()
+        .uri(new URI(wiremockServer.getUrl("/__admin/health")))
+        .timeout(Duration.ofSeconds(1))
+        .GET()
+        .build();
+
+      HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+      assertThat(response.statusCode()).isEqualTo(200);
+    }
+  }
+}


### PR DESCRIPTION
Add a [healthcheck](https://docs.docker.com/reference/dockerfile/#healthcheck) to the dockerfiles. This allows other docker tools, such as docker-compose or testcontainers, to check the health status of the container.

This was primarily motivated by the rust [testcontainers crate](https://crates.io/crates/testcontainers/0.16.3) not currently supporting HTTP calls as a [wait strategy](https://docs.rs/testcontainers/0.16.3/testcontainers/core/enum.WaitFor.html).

## References

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)