### PR TITLE
Bump base image to chainguard jdk image to reduce CVE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:20.0.2_9-jre
+FROM docker pull chainguard/jdk:openjdk-11.0.23
 
 LABEL maintainer="Rodolphe CHAIGNEAU <rodolphe.chaigneau@gmail.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.24_8-jre
+FROM eclipse-temurin:20.0.2_9-jre
 
 LABEL maintainer="Rodolphe CHAIGNEAU <rodolphe.chaigneau@gmail.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker pull chainguard/jdk:openjdk-11.0.23
+FROM chainguard/jdk:openjdk-11.0.23
 
 LABEL maintainer="Rodolphe CHAIGNEAU <rodolphe.chaigneau@gmail.com>"
 

--- a/Dockerfile-nightly
+++ b/Dockerfile-nightly
@@ -12,7 +12,7 @@ RUN ./gradlew shadowJar
 
 # RUN
 
-FROM eclipse-temurin:20.0.2_9-jre
+FROM chainguard/jdk:openjdk-11.0.23
 
 LABEL maintainer="Rodolphe CHAIGNEAU <rodolphe.chaigneau@gmail.com>"
 

--- a/Dockerfile-nightly
+++ b/Dockerfile-nightly
@@ -12,7 +12,7 @@ RUN ./gradlew shadowJar
 
 # RUN
 
-FROM eclipse-temurin:11.0.24_8-jre
+FROM eclipse-temurin:20.0.2_9-jre
 
 LABEL maintainer="Rodolphe CHAIGNEAU <rodolphe.chaigneau@gmail.com>"
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
