### PR TITLE
Updated Alpine Linux Java to 21

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 
 LABEL maintainer="Rodolphe CHAIGNEAU <rodolphe.chaigneau@gmail.com>"
 

--- a/alpine/Dockerfile-nightly
+++ b/alpine/Dockerfile-nightly
@@ -10,7 +10,7 @@ RUN ./gradlew shadowJar
 
 # RUN
 
-FROM eclipse-temurin:11.0.20_8-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 
 LABEL maintainer="Rodolphe CHAIGNEAU <rodolphe.chaigneau@gmail.com>"
 


### PR DESCRIPTION
We use wiremock alpine in our company, but its been flagged because of insecure Java 11 version. With this PR the version will be JRE 21 and remove the java security warnings

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ x ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ x ] The PR request is well described and justified, including the body and the references
- [ x ] The PR title represents the desired changelog entry
- [ x ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
